### PR TITLE
fix bad pc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 build/
 
-# local .vimrc
+# local .vimrc .vscode
 .vimrc
 *.swp
+.vscode
 
 .build/
 

--- a/Source/PurCFetcher/ports/linux/purc_fetcher.pc.in
+++ b/Source/PurCFetcher/ports/linux/purc_fetcher.pc.in
@@ -1,11 +1,11 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-includedir=${prefix}/@includedir@
-libdir=${prefix}/@libdir@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: PurCFetcher
-Description: The sample profject for VincentWei's C language course.
-URL: https://github.com/VincentWei/best-practices-of-c
+Description: The remote data fetcher for PurC.
+URL: https://github.com/HVML/PurC-Fetcher
 Version: @PROJECT_VERSION@
 Requires.private: @PURCFETCHER_PKGCONFIG_REQUIRES@
 Libs: -L${libdir} -lpurc_fetcher


### PR DESCRIPTION
Signed-off-by: Jin Tang Cheng <jtcheng@cqu.edu.cn>
In this PR:
1. fix the bad purc_fetcher pc file
2. add .vscode to gitignore

After the fix, the built out pc file is like:
```
jtcheng@devpc:~/lnx_works/PurC-Fetcher/build$ cat src/purc_fetcher/purc_fetcher.pc
prefix=/usr/local
exec_prefix=${prefix}
libdir=${prefix}/lib
includedir=${prefix}/include

Name: PurCFetcher
Description: The remote data fetcher for PurC.
URL: https://github.com/HVML/PurC-Fetcher
Version: 1.0.0
Requires.private:
Libs: -L${libdir} -lpurc_fetcher
Libs.private:
Cflags: -I${includedir}
```